### PR TITLE
REL-494444 Add Version Compatibility information for Hosting nugets

### DIFF
--- a/Relativity.API.md
+++ b/Relativity.API.md
@@ -1,8 +1,8 @@
 # Relativity.API Version Compatibility
 
-![Nuget](https://img.shields.io/nuget/v/Relativity.API)
+[![nuget](https://img.shields.io/nuget/v/Relativity.API.svg)](https://www.nuget.org/packages/Relativity.API)
 
-The Relativity API .NET package.
+The interfaces and data objects for Relativity Extensability Points.
 
 ## v15.6.3.1
 

--- a/Relativity.API.md
+++ b/Relativity.API.md
@@ -1,0 +1,17 @@
+# Relativity.API Version Compatibility
+
+![Nuget](https://img.shields.io/nuget/v/Relativity.API)
+
+The Relativity API .NET package.
+
+## v15.6.3.1
+
+### Release Notes
+
+Initial Version
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.1.0.0 | Latest

--- a/Relativity.CustomPages.md
+++ b/Relativity.CustomPages.md
@@ -1,6 +1,6 @@
 # Relativity.CustomPages Version Compatibility
 
-![Nuget](https://img.shields.io/nuget/v/Relativity.CustomPages)
+[![nuget](https://img.shields.io/nuget/v/Relativity.CustomPages.svg)](https://www.nuget.org/packages/Relativity.CustomPages)
 
 The Relativity custom pages framework .NET package.
 

--- a/Relativity.CustomPages.md
+++ b/Relativity.CustomPages.md
@@ -1,0 +1,17 @@
+# Relativity.CustomPages Version Compatibility
+
+![Nuget](https://img.shields.io/nuget/v/Relativity.CustomPages)
+
+The Relativity custom pages framework .NET package.
+
+## v15.6.1.1
+
+### Release Notes
+
+Initial Version
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.1.0.0 | Latest

--- a/Relativity.Kepler.md
+++ b/Relativity.Kepler.md
@@ -1,6 +1,6 @@
 # Relativity.Kepler Version Compatibility
 
-![Nuget](https://img.shields.io/nuget/v/Relativity.Kepler)
+[![nuget](https://img.shields.io/nuget/v/Relativity.Kepler.svg)](https://www.nuget.org/packages/Relativity.Kepler)
 
 The Relativity Kepler SDK for our Kepler APIs.
 

--- a/Relativity.Kepler.md
+++ b/Relativity.Kepler.md
@@ -1,0 +1,17 @@
+# Relativity.Kepler Version Compatibility
+
+![Nuget](https://img.shields.io/nuget/v/Relativity.Kepler)
+
+The Relativity Kepler SDK for our Kepler APIs.
+
+## v2.13.0.0
+
+### Release Notes
+
+Initial Version
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.1.0.0 | Latest

--- a/Relativity.Shared.SDK.md
+++ b/Relativity.Shared.SDK.md
@@ -1,6 +1,6 @@
 # Relativity.Shared.SDK Version Compatibility
 
-![Nuget](https://img.shields.io/nuget/v/Relativity.Shared.SDK)
+[![nuget](https://img.shields.io/nuget/v/Relativity.Shared.SDK.svg)](https://www.nuget.org/packages/Relativity.Shared.SDK)
 
 The Relativity Shared SDK for our shared library of APIs.
 

--- a/Relativity.Shared.SDK.md
+++ b/Relativity.Shared.SDK.md
@@ -1,0 +1,17 @@
+# Relativity.Shared.SDK Version Compatibility
+
+![Nuget](https://img.shields.io/nuget/v/Relativity.Shared.SDK)
+
+The Relativity Shared SDK for our shared library of APIs.
+
+## v1.5.0.0
+
+### Release Notes
+
+Initial Version
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.1.0.0 | Latest


### PR DESCRIPTION
REL-494444

I'm adding Version Compatibility information for Relativity.API, Relativity.Shared.SDK, Relativity.Kepler and Relativity.CustomPages so these packages can be published to the NuGet pipeline