### PR TITLE
REL-538503 Update compatibility 

### DIFF
--- a/Relativity.Audit.SDK.md
+++ b/Relativity.Audit.SDK.md
@@ -19,7 +19,7 @@ Relativity Audit API definitions for use with Kepler proxy generation.
 
 Lowest Version | Highest Version
 --- | ---
-12.0.0.0 | Latest
+12.1.0.0 | Latest
 
 ### Supported Audit RAP Version Range
 

--- a/Relativity.Audit.SDK.md
+++ b/Relativity.Audit.SDK.md
@@ -6,8 +6,10 @@ Relativity Audit API definitions for use with Kepler proxy generation.
 
 ## v1.7.0
 
-### Release Notes
+### Note
+* Any version greater than 17.2.3 of Relativity.Audit.Services.SDK should not be used until Osier-0 is released. 
 
+### Release Notes
 * The first release of Relativity.Audit.SDK.
 * Contains V1 versioned Kepler endpoint definitions for Audit.
 * This package replaces Relativity.Audit.Services.SDK starting from v18.0.1.


### PR DESCRIPTION
Updating docs to reflect a compatibility issue. 
 Any version greater than 17.2.3 of Relativity.Audit.Services.SDK should not be used until Osier-0 is released due to a bug with single choice field versioning.