### PR TITLE
REL-538503 Clarifying compatibility.

### DIFF
--- a/Relativity.Audit.SDK.md
+++ b/Relativity.Audit.SDK.md
@@ -6,14 +6,15 @@ Relativity Audit API definitions for use with Kepler proxy generation.
 
 ## v1.7.0
 
-### Note
-* Any version greater than 17.2.3 of Relativity.Audit.Services.SDK should not be used until Osier-0 is released. 
-
 ### Release Notes
 * The first release of Relativity.Audit.SDK.
 * Contains V1 versioned Kepler endpoint definitions for Audit.
 * This package replaces Relativity.Audit.Services.SDK starting from v18.0.1.
-* Package contents are functionally identical to Relativity.Audit.Services.SDK v18.0.1.
+* Package contents for Relativity.Audit.SDK v1.7 are functionally identical to Relativity.Audit.Services.SDK v18.0.1.
+
+### Note
+* Audit RAP v22.2.10 will be provided with Osier (12.1.0.0) release.
+* If using a Relativity version older than Osier (12.1.0.0) then use Relativity.Audit.Services.SDK version 17.2.3.
 
 ### Supported Relativity Version Range
 
@@ -25,4 +26,4 @@ Lowest Version | Highest Version
 
 Lowest Version | Highest Version
 --- | ---
-21.0.0 | Latest
+22.2.10 | Latest


### PR DESCRIPTION
Clarifying Audit version and Relativity compatibility.
Clarifying that Relativity.Audit.SDK v1.7 is functionally identical to Relativity.Audit.Services.SDK v18.0.1