### PR TITLE
REL-550161

### DIFF
--- a/Relativity.Infrastructure.SDK.md
+++ b/Relativity.Infrastructure.SDK.md
@@ -4,7 +4,7 @@
 
 This package contains interfaces for interacting with our Relativity Infrastructure APIs via .NET.
 
-## v4.0.0
+## v4.0.1
 
 ### Release Notes
 


### PR DESCRIPTION
Changed version number in Relativity.Infrastructure.SDK package compatibility info to 4.0.1.

Version had to be changed from 4.0.0 to 4.0.1 to include Relativity NuGet logo (icon), which is required for publishing.
Related PR in the Relativity.Infrastructure.SDK repo: https://git.kcura.com/projects/REL/repos/relativity-infrastructure/pull-requests/37/overview