### PR TITLE
REL-550161

### DIFF
--- a/Relativity.Infrastructure.SDK.md
+++ b/Relativity.Infrastructure.SDK.md
@@ -4,7 +4,7 @@
 
 This package contains interfaces for interacting with our Relativity Infrastructure APIs via .NET.
 
-## v4.0.1
+## v4.0.2
 
 ### Release Notes
 


### PR DESCRIPTION
Changed version number in Relativity.Infrastructure.SDK package compatibility info to 4.0.2.

Version had to be changed from 4.0.1 to 4.0.2 to include changes in the nuspec file regarding the NuGet icon, which are required for publishing.
Related PR in the Relativity.Infrastructure.SDK repo: https://git.kcura.com/projects/REL/repos/relativity-infrastructure/pull-requests/38/overview