### PR TITLE
Update Relativity.Infrastructure.SDK to 4.1.0

### DIFF
--- a/Relativity.Infrastructure.SDK.md
+++ b/Relativity.Infrastructure.SDK.md
@@ -4,7 +4,7 @@
 
 This package contains interfaces for interacting with our Relativity Infrastructure APIs via .NET.
 
-## v4.0.3
+## v4.1.0
 
 ### Release Notes
 


### PR DESCRIPTION
I realized I added the wrong version, the version of Relativity.Infrastructure.SDK that was published is 4.1.0, not 4.0.3