### PR TITLE
REL-569182 update initial release version

### DIFF
--- a/Relativity.StructuredAnalytics.SDK.md
+++ b/Relativity.StructuredAnalytics.SDK.md
@@ -4,7 +4,7 @@
 
 This package contains interfaces for the Structured Analytics public APIs.
 
-## v1.18.3
+## v1.19.1
 
 ### Release Notes
 


### PR DESCRIPTION
Version 1.18.3 failed package validation in the package publishing pipeline.  v1.19.1 is now published and is the initial public release of this package.