### PR TITLE
REL-679377 update nuget version compatibility file for Relativity.SearchTermsReport.SDK

### DIFF
--- a/Relativity.SearchTermsReport.SDK.md
+++ b/Relativity.SearchTermsReport.SDK.md
@@ -4,6 +4,23 @@
 
 This package contains interfaces for the public APIs of the Relativity SearchTermsReport application.
 
+## v13.6.14
+
+### Release Notes
+* Added CancelJob, IndexContainsLongTextField, and GetRetry endpoints
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.1.0.0 | Latest
+
+### Supported RAP Version Range
+
+Lowest Version | Highest Version
+--- | ---
+13.6.8.0 | Latest
+
 ## v13.2.10
 
 ### Release Notes


### PR DESCRIPTION
Updating the version compatibility file for Relativity.SearchTermsReport.SDK so that our clients can get the most recent STR API interface.