### PR TITLE
REL-829868 Adding markdown files for Relativity.Pivot and Relativity ColorMap SDKs

### DIFF
--- a/Relativity.ColorMap.SDK.md
+++ b/Relativity.ColorMap.SDK.md
@@ -4,7 +4,7 @@
 
 Relativity ColorMap definitions for use with Kepler proxy generations.
 
-## v13.3.x
+## v13.3.3
 
 ### Release Notes
 
@@ -20,4 +20,4 @@ Lowest Version | Highest Version
 
 Lowest Version | Highest Version
 --- | ---
-13.3.x | Latest
+13.3.3 | Latest

--- a/Relativity.ColorMap.SDK.md
+++ b/Relativity.ColorMap.SDK.md
@@ -1,0 +1,23 @@
+# Relativity.ColorMap.SDK Version Compatibility
+
+[![nuget](https://img.shields.io/nuget/v/Relativity.ColorMap.SDK.svg)](https://www.nuget.org/packages/Relativity.ColorMap.SDK/)
+
+Relativity ColorMap definitions for use with Kepler proxy generations.
+
+## v13.3.x
+
+### Release Notes
+
+* Initial public consumable SDK of Relativity ColorMap APIs.
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+13.1.0.0 | Latest
+
+### Supported ColorMap RAP Version Range
+
+Lowest Version | Highest Version
+--- | ---
+13.3.x | Latest

--- a/Relativity.Pivot.SDK.md
+++ b/Relativity.Pivot.SDK.md
@@ -4,7 +4,7 @@
 
 Relativity Pivot definitions for use with Kepler proxy generations.
 
-## v2.2.x
+## v3.0.0
 
 ### Release Notes
 
@@ -20,4 +20,4 @@ Lowest Version | Highest Version
 
 Lowest Version | Highest Version
 --- | ---
-2.2.x | Latest
+3.0.0 | Latest

--- a/Relativity.Pivot.SDK.md
+++ b/Relativity.Pivot.SDK.md
@@ -1,0 +1,23 @@
+# Relativity.Pivot.SDK Version Compatibility
+
+[![nuget](https://img.shields.io/nuget/v/Relativity.Pivot.SDK.svg)](https://www.nuget.org/packages/Relativity.Pivot.SDK/)
+
+Relativity Pivot definitions for use with Kepler proxy generations.
+
+## v2.2.x
+
+### Release Notes
+
+* Initial public consumable SDK of Relativity Pivot APIs.
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.3.0.0 | Latest
+
+### Supported Pivot RAP Version Range
+
+Lowest Version | Highest Version
+--- | ---
+2.2.x | Latest


### PR DESCRIPTION
Adding new markdown files to enable these SDKs to be published to the public nuget and to be added to the Relativity Platform doc site. 