### PR TITLE
Compatibility updates for Relativity.Processing.SDK version 12.5.824

### DIFF
--- a/Relativity.Processing.SDK.md
+++ b/Relativity.Processing.SDK.md
@@ -4,6 +4,25 @@
 
 This package contains interfaces for the public APIs of the Relativity Processing application.
 
+## 12.5.824
+
+### Release Notes
+
+* Add endpoint to streamline data source creation.
+* Public model for OCR language mapping.
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+13.2.2 | Latest 13.2
+
+### Supported RAP Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.5.824 | Latest 12.5
+
 ## 12.5.41
 
 ### Release Notes

--- a/Relativity.Processing.SDK.md
+++ b/Relativity.Processing.SDK.md
@@ -4,7 +4,7 @@
 
 This package contains interfaces for the public APIs of the Relativity Processing application.
 
-## 12.5.858
+## 12.5.870
 
 ### Release Notes
 
@@ -22,7 +22,7 @@ Lowest Version | Highest Version
 
 Lowest Version | Highest Version
 --- | ---
-12.5.857 | Latest 12.5
+12.5.870 | Latest 12.5
 
 ## 12.5.41
 

--- a/Relativity.Processing.SDK.md
+++ b/Relativity.Processing.SDK.md
@@ -4,12 +4,13 @@
 
 This package contains interfaces for the public APIs of the Relativity Processing application.
 
-## 12.5.824
+## 12.5.858
 
 ### Release Notes
 
 * Add endpoint to streamline data source creation.
 * Public model for OCR language mapping.
+* Upgrade Kepler to 2.23.1
 
 ### Supported Relativity Version Range
 
@@ -21,7 +22,7 @@ Lowest Version | Highest Version
 
 Lowest Version | Highest Version
 --- | ---
-12.5.824 | Latest 12.5
+12.5.857 | Latest 12.5
 
 ## 12.5.41
 

--- a/Relativity.Processing.SDK.md
+++ b/Relativity.Processing.SDK.md
@@ -10,13 +10,13 @@ This package contains interfaces for the public APIs of the Relativity Processin
 
 * Add endpoint to streamline data source creation.
 * Public model for OCR language mapping.
-* Upgrade Kepler to 2.23.1
+* Upgrade package dependencies.
 
 ### Supported Relativity Version Range
 
 Lowest Version | Highest Version
 --- | ---
-13.2.2 | Latest 13.2
+24.3 | Latest 24.3
 
 ### Supported RAP Version Range
 


### PR DESCRIPTION
Compatibility updates for Relativity.Processing.SDK version 12.5.824. Please wait to merge until we get confirmation from client.