### PR TITLE
Update Relativity.API.Extensions release notes for v20.0.1

### DIFF
--- a/Relativity.API.Extensions.md
+++ b/Relativity.API.Extensions.md
@@ -2,7 +2,7 @@
 
 [![nuget](https://img.shields.io/nuget/v/Relativity.API.Extensions.svg)](https://www.nuget.org/packages/Relativity.API.Extensions)
 
-This library provides extension methods for the IServicesMgr interface for connecting multi-tenant microservices
+The `Relativity.API.Extensions` library provides helper methods for connecting ADS components to multi-tenant microservices. It provides two extension methods for `IServicesMgr` to discover the tenant host name and get an authorization token for use with the [HttpClient](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient) class.
 
 ## v20.0.1
 


### PR DESCRIPTION
Removed dependency on Relativity.Logging and updated minimum dependency version to v20.0.0.