### PR TITLE
Update Relativity.Import.SDK to 1.7.4

### DIFF
--- a/Relativity.Import.Models.SDK.md
+++ b/Relativity.Import.Models.SDK.md
@@ -4,6 +4,11 @@
 
 The Relativity Import Models SDK package contains contracts models for interacting with Relativity Import APIs via .NET.
 
+## v1.7.4
+
+### Release Notes
+* Version up to synchronize with Relativity.Import.SDK
+
 ## v1.2.1
 
 ### Release Notes

--- a/Relativity.Import.SDK.md
+++ b/Relativity.Import.SDK.md
@@ -4,6 +4,15 @@
 
 The Relativity Import SDK package contains interfaces for interacting with Relativity Import APIs via .NET.
 
+## v1.7.4
+
+### Release Notes
+
+* Extended FieldMapping with MayContainTranscript property for long text fields, including Extracted Text. Added WithTranscript/WithoutTranscript builder methods.
+* Added DocumentsImported option to ProgressElementAllowedNames for image import progress tracking.
+* Added DetailedProgress property to ImportProgress model with a list of ProgressElement objects to track progress across subsequent import stages.
+* Updated ImageSettingsBuilder to enforce that extracted text cannot be enabled together with production import.
+
 ## v1.2.1
 
 ### Release Notes


### PR DESCRIPTION
Update release notes for `Relativity.Import.SDK` and `Relativity.Import.Models.SDK` from v1.2.1 to v1.7.4. The last publicly available version on NuGet.org is 1.2.1, preparing to publish v1.7.4.