### PR TITLE
REL-1289909 Add v1.32.0 release notes for Relativity.StructuredAnalytics.SDK

### DIFF
--- a/Relativity.StructuredAnalytics.SDK.md
+++ b/Relativity.StructuredAnalytics.SDK.md
@@ -4,6 +4,24 @@
 
 This package contains interfaces for the Structured Analytics public APIs.
 
+## v1.31.0
+
+### Release Notes
+
+* Update NuGet icon to current Relativity logo across all SDK packages.
+
+### Supported Relativity Version Range
+
+Lowest Version | Highest Version
+--- | ---
+12.3.178.2 | Latest
+
+### Supported RAP Version Range
+
+Lowest Version | Highest Version
+--- | ---
+13.0.1.1 | Latest
+
 ## v1.19.1
 
 ### Release Notes

--- a/Relativity.StructuredAnalytics.SDK.md
+++ b/Relativity.StructuredAnalytics.SDK.md
@@ -10,6 +10,7 @@ This package contains interfaces for the Structured Analytics public APIs.
 
 * New `IJobManager` endpoints for retrieving document errors for a structured analytics set.
 * New `IJobManager` contracts to generate summary report data for structured analytics jobs.
+* Updated NuGet icon to current Relativity logo.
 
 ### Supported Relativity Version Range
 

--- a/Relativity.StructuredAnalytics.SDK.md
+++ b/Relativity.StructuredAnalytics.SDK.md
@@ -8,7 +8,8 @@ This package contains interfaces for the Structured Analytics public APIs.
 
 ### Release Notes
 
-* Update NuGet icon to current Relativity logo across all SDK packages.
+* New `IJobManager` endpoints for retrieving document errors for a structured analytics set.
+* New `IJobManager` contracts to generate summary report data for structured analytics jobs.
 
 ### Supported Relativity Version Range
 


### PR DESCRIPTION
## Summary

- Adds v1.32.0 entry to `Relativity.StructuredAnalytics.SDK.md`
- Skips v1.31.0 (not going public)
- Release notes: new `IJobManager` doc-error endpoints; NuGet icon updated to current Relativity logo
- `GenerateSummaryReportDataAsync` removed from release notes — method was pulled from `IJobManager` before publish (never implemented in the RAP)
- Supported Relativity and RAP version ranges unchanged from v1.19.1